### PR TITLE
Improve startup and shutdown speed

### DIFF
--- a/Playlists/Parsers/Base.cs
+++ b/Playlists/Parsers/Base.cs
@@ -54,11 +54,9 @@ namespace Stoffi.Core.Playlists
 			{
 				if (path.StartsWith("http://") || path.StartsWith("https://"))
 				{
-					U.L(LogLevel.Debug, "Playlist parser", "Downloading from " + path);
 					var request = (HttpWebRequest)WebRequest.Create(path);
 					using (var response = (HttpWebResponse)request.GetResponse())
 					{
-						U.L(LogLevel.Debug, "Playlist parser", "Parsing response from " + path);
 						var stream = response.GetResponseStream();
 						var encoding = Encoding.GetEncoding("utf-8");
 						using (var reader = new StreamReader(stream, encoding))

--- a/Playlists/Playlists.cs
+++ b/Playlists/Playlists.cs
@@ -339,12 +339,10 @@ namespace Stoffi.Core.Playlists
 		/// <returns>A list of playlists found at the path</returns>
 		public static List<Playlist> Parse(string path, bool resolveMetaData = true)
 		{
-			U.L (LogLevel.Debug, "Playlist", "Looking for a parser for " + path);
 			foreach (var parser in GetParsers (path))
 			{
 				try {
 					var playlists = parser.Read (path, resolveMetaData);
-					U.L (LogLevel.Debug, "Playlist", "Found parser: " + parser.GetType().Name);
 					return playlists;
 				}
 				catch (Exception e) {

--- a/Settings/Database.cs
+++ b/Settings/Database.cs
@@ -58,6 +58,7 @@ namespace Stoffi.Core.Settings
 		#region Constructor
 		public Database(string filename)
 		{
+			U.L(LogLevel.Information, "Database", "Initializing SQLite database");
 			if (!File.Exists(filename))
 				SQLiteConnection.CreateFile(filename);
 			dbConnection = "uri=file:settings.s3db";

--- a/Settings/Database.cs
+++ b/Settings/Database.cs
@@ -340,7 +340,7 @@ namespace Stoffi.Core.Settings
 		static Manager()
 		{
 			U.L(LogLevel.Information, "Settings", "Initializing database");
-			InitializeDatabase(true);
+			InitializeDatabase();
 			U.L(LogLevel.Debug, "Settings", "Database is initialized");
 		}
 

--- a/Settings/Database.cs
+++ b/Settings/Database.cs
@@ -285,7 +285,7 @@ namespace Stoffi.Core.Settings
 			{
 				try
 				{
-					var trans = cnn.BeginTransaction(IsolationLevel.Serializable);
+					//var trans = cnn.BeginTransaction(IsolationLevel.Serializable);
 					foreach (var cmd in commands)
 					{
 						new SQLiteCommand(cnn)
@@ -293,7 +293,7 @@ namespace Stoffi.Core.Settings
 							CommandText = cmd
 						}.ExecuteNonQuery();
 					}
-					trans.Commit();
+					//trans.Commit();
 					lock (nonQueryLock) { commandInQueue = false; }
 					return;
 				}
@@ -2205,7 +2205,6 @@ namespace Stoffi.Core.Settings
 					break;
 				}
 			}
-			U.L(LogLevel.Debug, "Database", "Property "+property+" saved");
 		}
 
 		/// <summary>

--- a/Settings/Database.cs
+++ b/Settings/Database.cs
@@ -53,17 +53,23 @@ namespace Stoffi.Core.Settings
 		#region Members
 		private string dbConnection;
 		private SQLiteConnection cnn;
+		// setup timer, used to bulk multiple, subsequent calls to ExecuteNonQuery
+		private Timer nonQueryTimer;
+		private List<string> nonQueries = new List<string>();
+		private object nonQueryLock = new object();
+		private bool commandInQueue = false;
 		#endregion
 
 		#region Constructor
 		public Database(string filename)
 		{
-			U.L(LogLevel.Information, "Database", "Initializing SQLite database");
 			if (!File.Exists(filename))
 				SQLiteConnection.CreateFile(filename);
 			dbConnection = "uri=file:settings.s3db";
-			cnn = new SQLiteConnection (dbConnection);
-			cnn.Open ();
+			U.L(LogLevel.Debug, "Database", "Creating connection");
+			cnn = new SQLiteConnection(dbConnection);
+			U.L(LogLevel.Debug, "Database", "Opening connection");
+			cnn.Open();
 		}
 		public static string[] Split(string source, char separator)
 		{
@@ -146,24 +152,17 @@ namespace Stoffi.Core.Settings
 			return dt;
 		}
 
-		public int ExecuteNonQuery(string sql)
+		public void ExecuteNonQuery(string sql)
 		{
-			var fails = 0;
-			var maxAttempts = 5;
-			while (fails < maxAttempts) {
-				try
-				{
-					var cmd = new SQLiteCommand (cnn);
-					cmd.CommandText = sql;
-					var rowsUpdated = cmd.ExecuteNonQuery ();
-					return rowsUpdated;
-				}
-				catch (Exception e) {
-					U.L (LogLevel.Error, "Settings", "Error executing non-query in database: " + e.Message);
-				}
-				fails++;
+			lock (nonQueryLock)
+			{
+				commandInQueue = true;
+				if (nonQueryTimer == null)
+					nonQueryTimer = new Timer(NonQueryTimer_Tick, null, 50, Timeout.Infinite);
+				else
+					nonQueryTimer.Change(50, Timeout.Infinite);
+				nonQueries.Add(sql);
 			}
-			return 0;
 		}
 
 		public string ExecuteScalar(string sql)
@@ -188,40 +187,56 @@ namespace Stoffi.Core.Settings
 			return ExecuteReader (sql);
 		}
 
-		public int Insert(string table, Dictionary<string,string> data)
+		public void Insert(string table, Dictionary<string,string> data)
 		{
 			var columns = String.Join (", ", from d in data select d.Key);
 			var values = String.Join (", ", from d in data select d.Value);
-			return ExecuteNonQuery (String.Format ("insert into {0}({1}) values({2});", table, columns, values));
+			ExecuteNonQuery (String.Format ("insert into {0}({1}) values({2});", table, columns, values));
+		}
+
+		public void BulkInsert(string table, IEnumerable<Dictionary<string, string>> data)
+		{
+			if (data.Count() == 0)
+				return;
+
+			var columns = String.Join(", ", from d in data.ElementAt(0) select d.Key);
+			List<string> rows = new List<string>();
+			foreach (var d in data)
+			{
+				rows.Add("(" + String.Join(", ", from x in d select x.Value) + ")");
+			}
+			var values = String.Join(", ", rows);
+			ExecuteNonQuery(String.Format("insert into {0}({1}) values {2};", table, columns, values));
 		}
 
 		public int LastID(string table)
 		{
+			AwaitCommand();
 			var data = ExecuteReader (String.Format("select max(rowid) as id from {0};", table));
 			if (data.Rows.Count == 0)
 				return -1;
 			return Convert.ToInt32 (data.Rows [0]["id"].ToString ());
 		}
 
-		public int Update(string table, Dictionary<string,string> data, string filter)
+		public void Update(string table, Dictionary<string,string> data, string filter)
 		{
 			var vals = "";
 			if (data.Count > 0)
 				vals = String.Join (",", from d in data select String.Format ("{0}={1}", d.Key, d.Value));
-			return ExecuteNonQuery (String.Format ("update {0} set {1} where {2};", table, vals, filter));
+			ExecuteNonQuery (String.Format ("update {0} set {1} where {2};", table, vals, filter));
 		}
 
-		public int Delete(string table, string filter)
+		public void Delete(string table, string filter)
 		{
-			return ExecuteNonQuery (String.Format ("delete from {0} where {1};", table, filter));
+			ExecuteNonQuery (String.Format ("delete from {0} where {1};", table, filter));
 		}
 
-		public int Delete(string table)
+		public void Delete(string table)
 		{
-			return Delete (table, "1");
+			Delete (table, "1");
 		}
 
-		public int CreateTable(string name, string[] textFields = null, string[] integerFields = null, string[] realFields = null)
+		public void CreateTable(string name, string[] textFields = null, string[] integerFields = null, string[] realFields = null)
 		{
 			var sql = "create table if not exists " + name + " (";
 
@@ -246,7 +261,49 @@ namespace Stoffi.Core.Settings
 
 			sql += String.Join (", ", fieldGroups);
 			sql += ");";
-			return ExecuteNonQuery (sql);
+			ExecuteNonQuery (sql);
+		}
+
+		public void AwaitCommand()
+		{
+			while (commandInQueue) ;
+		}
+
+		private void NonQueryTimer_Tick(object state)
+		{
+			List<string> commands;
+			lock (nonQueryLock)
+			{
+				commands = nonQueries.ToList();
+				nonQueries.Clear();
+				nonQueryTimer.Dispose();
+				nonQueryTimer = null;
+			}
+			var fails = 0;
+			var maxAttempts = 5;
+			while (fails < maxAttempts)
+			{
+				try
+				{
+					var trans = cnn.BeginTransaction(IsolationLevel.Serializable);
+					foreach (var cmd in commands)
+					{
+						new SQLiteCommand(cnn)
+						{
+							CommandText = cmd
+						}.ExecuteNonQuery();
+					}
+					trans.Commit();
+					lock (nonQueryLock) { commandInQueue = false; }
+					return;
+				}
+				catch (Exception e)
+				{
+					U.L(LogLevel.Error, "Settings", "Error executing non-query in database: " + e.Message);
+				}
+				fails++;
+			}
+			lock (nonQueryLock) { commandInQueue = false; }
 		}
 
 		#endregion
@@ -282,7 +339,9 @@ namespace Stoffi.Core.Settings
 		/// </summary>
 		static Manager()
 		{
-			InitializeDatabase();
+			U.L(LogLevel.Information, "Settings", "Initializing database");
+			InitializeDatabase(true);
+			U.L(LogLevel.Debug, "Settings", "Database is initialized");
 		}
 
 		#endregion
@@ -700,8 +759,12 @@ namespace Stoffi.Core.Settings
 			if (reset && File.Exists(path))
 				File.Delete(path);
 
+			U.L(LogLevel.Debug, "Database", "Creating new database instance");
 			db = new Database(path);
+			U.L(LogLevel.Debug, "Database", "Creating new database unless it exists");
 			CreateDatabase();
+			db.AwaitCommand();
+			U.L(LogLevel.Debug, "Database", "Loading database into memory");
 			LoadDatabase();
 		}
 
@@ -2142,6 +2205,7 @@ namespace Stoffi.Core.Settings
 					break;
 				}
 			}
+			U.L(LogLevel.Debug, "Database", "Property "+property+" saved");
 		}
 
 		/// <summary>
@@ -2176,8 +2240,8 @@ namespace Stoffi.Core.Settings
 			{
 				try
 				{
-					foreach (var track in tracks)
-						SaveTrack(track, table);
+					var data = (from t in tracks select CreateData(t)).ToList();
+					db.BulkInsert(table, data);
 					break;
 				}
 				catch (InvalidOperationException e) { } // collection was modified while trying to save
@@ -2298,8 +2362,10 @@ namespace Stoffi.Core.Settings
 		/// <param name="parentID">The ID of the config row.</param>
 		private static void SaveColumns(IEnumerable<ListColumn> columns, string table, int parentID)
 		{
-			foreach (var column in columns)
-				SaveColumn (column, table, parentID);
+			var data = (from x in columns select CreateData(x)).ToList();
+			foreach (var x in data)
+				x.Add("config", DBEncode(parentID));
+			db.BulkInsert(table, data);
 		}
 
 		/// <summary>
@@ -2346,8 +2412,9 @@ namespace Stoffi.Core.Settings
 		/// <param name="parentID">The ID of the profile row.</param>
 		private static void SaveShortcuts(IEnumerable<KeyboardShortcut> shortcuts, string table, int parentID)
 		{
-			foreach (var shortcut in shortcuts)
-				SaveShortcut (shortcut, table, parentID);
+			var data = (from x in shortcuts select CreateData(x)).ToList();
+			foreach (var x in data) { x["profile"] = DBEncode(parentID); }
+			db.BulkInsert(table, data);
 		}
 
 		/// <summary>
@@ -2496,8 +2563,8 @@ namespace Stoffi.Core.Settings
 		/// <param name="table">Database table.</param>
 		private static void SaveSources(IEnumerable<Location> sources, string table)
 		{
-			foreach (var source in sources)
-				SaveSource (source, table);
+			var data = (from x in sources select CreateData(x)).ToList();
+			db.BulkInsert(table, data);
 		}
 
 		/// <summary>
@@ -2538,13 +2605,15 @@ namespace Stoffi.Core.Settings
 			data ["listConfig"] = DBEncode (db.LastID("listConfigurations"));
 			db.Update (table, data, String.Format("rowid={0}", rowid));
 
+			var d = new List<Dictionary<string, string>>();
 			foreach (var t in playlist.Tracks)
 			{
-				data.Clear ();
-				data ["path"] = DBEncode(t.Path);
-				data ["playlist"] = DBEncode (rowid);
-				db.Insert ("playlistTracks", data);
+				var x = new Dictionary<string, string>();
+				x["path"] = DBEncode(t.Path);
+				x["playlist"] = DBEncode(rowid);
+				d.Add(x);
 			}
+			db.BulkInsert("playlistTracks", d);
 		}
 
 		/// <summary>

--- a/Sources/Radio/Base.cs
+++ b/Sources/Radio/Base.cs
@@ -69,6 +69,6 @@ namespace Stoffi.Core.Sources.Radio
 		/// Fetch default radio stations and add to collection.
 		/// </summary>
 		/// <param name="stations">Station collection.</param>
-		public abstract void FetchStations(ObservableCollection<Track> stations);
+		public abstract List<Track> FetchStations();
 	}
 }

--- a/Sources/Radio/SomaFM.cs
+++ b/Sources/Radio/SomaFM.cs
@@ -19,6 +19,7 @@
  ***/
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
@@ -38,8 +39,9 @@ namespace Stoffi.Core.Sources.Radio
 		/// Fill collection with SomaFM stations.
 		/// </summary>
 		/// <param name="stations">Station collection.</param>
-		public override void FetchStations(ObservableCollection<Track> stations)
+		public override List<Track> FetchStations()
 		{
+			var stations = new List<Track>();
 			var stationGroup = "SomaFM";
 			try
 			{
@@ -57,7 +59,6 @@ namespace Stoffi.Core.Sources.Radio
 							{
 								xmlReader.MoveToAttribute("id");
 								var id = xmlReader.Value;
-								U.L(LogLevel.Debug, "SomaFM", "Adding SonaFM station "+id);
 								try
 								{
 									var station = new Track();
@@ -104,7 +105,6 @@ namespace Stoffi.Core.Sources.Radio
 												station.Path = station.URL;
 												if (Playlists.Manager.IsSupported(value))
 												{
-													U.L(LogLevel.Debug, "SomaFM", "Resolving streaming URL from "+value);
 													var playlists = Playlists.Manager.Parse(value, false);
 													if (playlists == null || playlists.Count == 0 || playlists[0].Tracks.Count == 0)
 														throw new Exception("No streaming URLs found at " + value);
@@ -123,7 +123,10 @@ namespace Stoffi.Core.Sources.Radio
 									}
 
 									if (!String.IsNullOrWhiteSpace(station.Path) && !U.ContainsPath(stations, station.Path))
-										AddStation("SomaFM", station, stations);
+									{
+										U.L(LogLevel.Information, "SomaFM", "Added radio station " + station.Path);
+										stations.Add(station);
+									}
 								}
 								catch (Exception e)
 								{
@@ -141,6 +144,7 @@ namespace Stoffi.Core.Sources.Radio
 			{
 				U.L(LogLevel.Warning, "SomaFM", "Could not retrieve SonaFM stations: " + e.Message);
 			}
+			return stations;
 		}
 	}
 }

--- a/Stoffi Player Core.csproj
+++ b/Stoffi Player Core.csproj
@@ -26,6 +26,7 @@ It's written to be portable and used on multiple platforms.</Description>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Do some various optimizations to improve startup- and shutdown speed:
- Bulk together multiple non-query calls to the database
- Add a lock to non-query calls to the database
- Add default radio stations in background and update GUI first when all stations has been parsed
- Borrow code from migrator which bulks calls from for example SettingsManager#SaveTracks
so all tracks (or columns, or shortcuts, etc) are inserted in a single query

This mainly affects the first startup and shutdown (when everything is first initialized). Subsequent sessions should have approx the same times as before.

Fixes simplare/stoffi-player-win#6